### PR TITLE
feat(server): implement Deno.serve HTTP server with routing

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,29 @@
+{
+  "tasks": {
+    "dev": "deno run --watch --allow-read --allow-env --allow-net --allow-sys --sloppy-imports src/index.ts",
+    "build": "deno compile --allow-read --allow-env --allow-net --allow-sys --sloppy-imports --output dist/index src/index.ts",
+    "start": "deno run --allow-read --allow-env --allow-net --allow-sys --sloppy-imports dist/index",
+    "type-check": "deno check --sloppy-imports src/index.ts",
+    "check": "deno lint src/ && deno check --sloppy-imports src/index.ts"
+  },
+  "imports": {
+    "@/": "./src/",
+    "reflect-metadata": "npm:reflect-metadata@^0.2.2",
+    "tsyringe": "npm:tsyringe@^4.10.0",
+    "zod": "npm:zod@^4.1.11",
+    "loglayer": "npm:loglayer@^6.7.2",
+    "@loglayer/transport-pino": "npm:@loglayer/transport-pino@^2.2.4",
+    "pino": "npm:pino@^10.0.0",
+    "pino-pretty": "npm:pino-pretty@^13.1.1",
+    "serialize-error": "npm:serialize-error@^12.0.0"
+  },
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -9,6 +9,8 @@ import { HelloWorldUseCase } from "@/application/use-cases/hello-world.use-case"
 import { AppConfig } from "@/infrastructure/config/app.config";
 // Import repositories
 import { MemoryUserRepository } from "@/infrastructure/repositories/memory-user.repository";
+//Import Server
+import { DenoServer } from "@/infrastructure/server/deno.server";
 // Import controllers
 import { HealthController } from "@/presentation/controllers/health.controller";
 import { HelloController } from "@/presentation/controllers/hello.controller";
@@ -18,6 +20,7 @@ import { LoggerService } from "@/shared/logger";
 // Import tokens
 import { TOKENS } from "@/tokens";
 
+container.registerSingleton(TOKENS.SERVER, DenoServer);
 // Singleton services (shared instances across app)
 container.registerSingleton(TOKENS.CONFIG_SERVICE, AppConfig);
 container.registerSingleton(TOKENS.LOGGER_SERVICE, LoggerService);

--- a/src/domain/interfaces/server.interface.ts
+++ b/src/domain/interfaces/server.interface.ts
@@ -1,0 +1,4 @@
+export interface IServer {
+	start(): Promise<void>;
+	stop(): void;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,44 +1,10 @@
 import { container } from "@/container";
-import type { HealthController } from "@/presentation/controllers/health.controller";
-import type { HelloController } from "@/presentation/controllers/hello.controller";
-import type { UserController } from "@/presentation/controllers/user.controller";
+import type { IServer } from "@/domain/interfaces/server.interface";
 import { TOKENS } from "@/tokens";
 
 async function main() {
-	// Get controllers from DI container
-	const helloController = container.resolve<HelloController>(
-		TOKENS.HELLO_CONTROLLER,
-	);
-	const healthController = container.resolve<HealthController>(
-		TOKENS.HEALTH_CONTROLLER,
-	);
-	const userController = container.resolve<UserController>(
-		TOKENS.USER_CONTROLLER,
-	);
-
-	// Test HelloWorld
-	console.log("\n=== Hello World ===");
-	const helloResult = await helloController.handle();
-	console.log(helloResult);
-
-	// Test Health Check
-	console.log("\n=== Health Check ===");
-	const healthResult = await healthController.handle();
-	console.log(healthResult);
-
-	// Test User Creation & Retrieval
-	console.log("\n=== Create User ===");
-	const newUser = await userController.createUser({
-		name: "John Doe",
-		email: "john@example.com",
-	});
-	console.log(newUser);
-
-	console.log("\n=== Get User ===");
-	const user = await userController.getUser(newUser.id);
-	console.log(user);
-
-	console.log("\n✅ Template is working correctly!");
+	const server = container.resolve<IServer>(TOKENS.SERVER);
+	await server.start();
 }
 
 main()

--- a/src/infrastructure/server/deno.server.ts
+++ b/src/infrastructure/server/deno.server.ts
@@ -6,6 +6,17 @@ import type { HealthController } from "@/presentation/controllers/health.control
 import type { HelloController } from "@/presentation/controllers/hello.controller";
 import { TOKENS } from "@/tokens";
 
+declare global {
+	const Deno: {
+		serve(options: {
+			port?: number;
+			hostname?: string;
+			signal?: AbortSignal;
+			handler: (request: Request) => Response | Promise<Response>;
+		}): { finished: Promise<void> };
+	};
+}
+
 @injectable()
 export class DenoServer implements IServer {
 	private abortController?: AbortController;

--- a/src/infrastructure/server/deno.server.ts
+++ b/src/infrastructure/server/deno.server.ts
@@ -1,0 +1,160 @@
+import { inject, injectable } from "tsyringe";
+import type { IConfig } from "@/domain/interfaces/config.interface";
+import type { ILogger } from "@/domain/interfaces/logger.interface";
+import type { IServer } from "@/domain/interfaces/server.interface";
+import type { HealthController } from "@/presentation/controllers/health.controller";
+import type { HelloController } from "@/presentation/controllers/hello.controller";
+import { TOKENS } from "@/tokens";
+
+@injectable()
+export class DenoServer implements IServer {
+	private abortController?: AbortController;
+
+	constructor(
+		@inject(TOKENS.CONFIG_SERVICE) private config: IConfig,
+		@inject(TOKENS.LOGGER_SERVICE) private logger: ILogger,
+		@inject(TOKENS.HEALTH_CONTROLLER)
+		private healthController: HealthController,
+		@inject(TOKENS.HELLO_CONTROLLER) private helloController: HelloController,
+	) {}
+
+	async start(): Promise<void> {
+		this.logger
+			.withData({
+				port: this.config.port,
+			})
+			.info("Starting Deno server...");
+
+		this.abortController = new AbortController();
+
+		try {
+			const server = Deno.serve({
+				port: this.config.port,
+				hostname: "0.0.0.0",
+				signal: this.abortController.signal,
+				handler: this.requestHandler.bind(this),
+			});
+
+			this.logger
+				.withData({
+					port: this.config.port,
+					hostname: "0.0.0.0",
+				})
+				.info("Deno server started successfully");
+
+			await server.finished;
+		} catch (error) {
+			this.logger
+				.withError(error as Error)
+				.error("Failed to start Deno server");
+			throw error;
+		}
+	}
+
+	stop(): void {
+		if (this.abortController) {
+			this.logger.info("Stopping Deno server...");
+			this.abortController.abort();
+		}
+	}
+
+	private async requestHandler(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		const { pathname } = url;
+
+		try {
+			// Add CORS headers
+			const corsHeaders = {
+				"Access-Control-Allow-Origin": "*",
+				"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+				"Access-Control-Allow-Headers": "Content-Type",
+			};
+
+			// Handle preflight requests
+			if (request.method === "OPTIONS") {
+				return new Response(null, { headers: corsHeaders });
+			}
+
+			// Router
+			switch (pathname) {
+				case "/health":
+					return await this.handleHealth(corsHeaders);
+				case "/hello":
+					return await this.handleHello(corsHeaders);
+				default:
+					return this.handle404(corsHeaders);
+			}
+		} catch (error) {
+			return this.handle500(error as Error);
+		}
+	}
+
+	private async handleHealth(
+		corsHeaders: Record<string, string>,
+	): Promise<Response> {
+		try {
+			const result = await this.healthController.handle();
+			return new Response(JSON.stringify(result), {
+				status: 200,
+				headers: {
+					...corsHeaders,
+					"Content-Type": "application/json",
+				},
+			});
+		} catch (error) {
+			this.logger.withError(error as Error).error("Health check failed");
+			return new Response(
+				JSON.stringify({ status: "error", message: "Health check failed" }),
+				{
+					status: 500,
+					headers: {
+						"Content-Type": "application/json",
+					},
+				},
+			);
+		}
+	}
+
+	private async handleHello(
+		corsHeaders: Record<string, string>,
+	): Promise<Response> {
+		try {
+			const result = await this.helloController.handle();
+			return new Response(JSON.stringify(result), {
+				status: 200,
+				headers: {
+					...corsHeaders,
+					"Content-Type": "application/json",
+				},
+			});
+		} catch (error) {
+			this.logger.withError(error as Error).error("Hello endpoint failed");
+			return new Response(JSON.stringify({ error: "Internal server error" }), {
+				status: 500,
+				headers: {
+					"Content-Type": "application/json",
+				},
+			});
+		}
+	}
+
+	private handle404(corsHeaders: Record<string, string>): Response {
+		return new Response(JSON.stringify({ error: "Not Found" }), {
+			status: 404,
+			headers: {
+				...corsHeaders,
+				"Content-Type": "application/json",
+			},
+		});
+	}
+
+	private handle500(error: Error): Response {
+		this.logger.withError(error).error("Unhandled server error");
+		return new Response(JSON.stringify({ error: "Internal Server Error" }), {
+			status: 500,
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+	}
+}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -3,6 +3,7 @@ const createToken = (name: string): symbol => Symbol.for(`ts-template.${name}`);
 
 // Export all tokens as TOKENS object with Symbol tokens
 export const TOKENS = {
+	SERVER: createToken("Server"),
 	// Repository tokens
 	USER_REPOSITORY: createToken("UserRepository"),
 


### PR DESCRIPTION
## Summary
- 🚀 Add Deno runtime configuration with proper permissions
- 🌐 Implement HTTP server using Deno.serve API with routing
- 🔗 Integrate server with dependency injection container
- 📡 Add /health and /hello endpoints with JSON responses
- 🛡️ Implement CORS headers and comprehensive error handling
- ⚡ Add graceful shutdown with AbortController

## Test Plan
- [ ] Run `deno task dev` - server starts successfully on port 3000
- [ ] Test `GET /health` endpoint returns health status with metadata
- [ ] Test `GET /hello` endpoint returns "Hello, World!" message
- [ ] Test `OPTIONS` preflight requests return proper CORS headers
- [ ] Test 404 handling for unknown routes
- [ ] Verify graceful shutdown functionality
- [ ] Confirm all hooks pass (lint + type-check)

## Commits
- `feat(deno): add Deno runtime configuration`
- `feat(server): implement Deno.serve HTTP server with routing`
- `feat(di): add server to dependency injection container`
- `refactor(app): update entry point to start HTTP server`
- `fix(server): add TypeScript declaration for Deno global`

## Breaking Changes
None

## Technical Details
- Uses Deno 2.5.3 stable API
- Follows Clean Architecture principles
- Integrates with existing HealthController and HelloController
- Maintains TypeScript strict mode compatibility